### PR TITLE
Log node disconnects with level `warn`

### DIFF
--- a/lib/strategy/strategy.ex
+++ b/lib/strategy/strategy.ex
@@ -102,7 +102,7 @@ defmodule Cluster.Strategy do
 
         case apply(disconnect_mod, disconnect_fun, fargs) do
           true ->
-            Cluster.Logger.info(topology, "disconnected from #{inspect(n)}")
+            Cluster.Logger.warn(topology, "disconnected from #{inspect(n)}")
             acc
 
           false ->


### PR DESCRIPTION
We want to see how disconnects behave when the deployment is updated.