### PR TITLE
Add Kubernetes.DNS.ConnectOnly strategy

### DIFF
--- a/lib/strategy/kubernetes_dns_connectonly.ex
+++ b/lib/strategy/kubernetes_dns_connectonly.ex
@@ -1,0 +1,117 @@
+defmodule Cluster.Strategy.Kubernetes.DNS.ConnectOnly do
+  @moduledoc """
+  This is the same as Cluster.Strategy.Kubernetes.DNS, but
+  it does not pro-actively disconnect nodes that do not appear in the DNS
+  resolver response.
+  We let Erlang Distribution take care of disconnecting nodes
+  """
+  use GenServer
+  use Cluster.Strategy
+  import Cluster.Logger
+
+  alias Cluster.Strategy.State
+
+  @default_polling_interval 5_000
+
+  @impl true
+  def start_link(args), do: GenServer.start_link(__MODULE__, args)
+
+  @impl true
+  def init([%State{meta: nil} = state]) do
+    init([%State{state | :meta => MapSet.new()}])
+  end
+
+  def init([%State{} = state]) do
+    {:ok, load(state), 0}
+  end
+
+  @impl true
+  def handle_info(:timeout, state) do
+    handle_info(:load, state)
+  end
+
+  def handle_info(:load, state) do
+    {:noreply, load(state)}
+  end
+
+  def handle_info(_, state) do
+    {:noreply, state}
+  end
+
+  defp load(%State{topology: topology} = state) do
+    new_nodelist = MapSet.new(get_nodes(state))
+
+    new_nodelist =
+      case Cluster.Strategy.connect_nodes(
+             topology,
+             state.connect,
+             state.list_nodes,
+             MapSet.to_list(new_nodelist)
+           ) do
+        :ok ->
+          new_nodelist
+
+        {:error, bad_nodes} ->
+          # Remove the nodes which should have been added, but couldn't be for some reason
+          Enum.reduce(bad_nodes, new_nodelist, fn {n, _}, acc ->
+            MapSet.delete(acc, n)
+          end)
+      end
+
+    Process.send_after(
+      self(),
+      :load,
+      polling_interval(state)
+    )
+
+    %State{state | meta: new_nodelist}
+  end
+
+  @spec get_nodes(State.t()) :: [atom()]
+  defp get_nodes(%State{topology: topology, config: config}) do
+    app_name = Keyword.fetch!(config, :application_name)
+    service = Keyword.fetch!(config, :service)
+    resolver = Keyword.get(config, :resolver, &:inet_res.getbyname(&1, :a))
+
+    cond do
+      app_name != nil and service != nil ->
+        headless_service = to_charlist(service)
+
+        case resolver.(headless_service) do
+          {:ok, {:hostent, _fqdn, [], :inet, _value, addresses}} ->
+            parse_response(addresses, app_name)
+
+          {:error, reason} ->
+            error(topology, "lookup against #{service} failed: #{inspect(reason)}")
+            []
+        end
+
+      app_name == nil ->
+        warn(
+          topology,
+          "kubernetes.DNS strategy is selected, but :application_name is not configured!"
+        )
+
+        []
+
+      service == nil ->
+        warn(topology, "kubernetes strategy is selected, but :service is not configured!")
+        []
+
+      :else ->
+        warn(topology, "kubernetes strategy is selected, but is not configured!")
+        []
+    end
+  end
+
+  defp polling_interval(%State{config: config}) do
+    Keyword.get(config, :polling_interval, @default_polling_interval)
+  end
+
+  defp parse_response(addresses, app_name) do
+    addresses
+    |> Enum.map(&:inet_parse.ntoa(&1))
+    |> Enum.map(&"#{app_name}@#{&1}")
+    |> Enum.map(&String.to_atom(&1))
+  end
+end

--- a/test/kubernetes_dns_connectonly_test.exs
+++ b/test/kubernetes_dns_connectonly_test.exs
@@ -1,4 +1,4 @@
-defmodule Cluster.Strategy.KubernetesDNSTest do
+defmodule Cluster.Strategy.KubernetesDNSConnectOnlyTest do
   @moduledoc false
 
   use ExUnit.Case, async: true
@@ -29,14 +29,14 @@ defmodule Cluster.Strategy.KubernetesDNSTest do
             list_nodes: {Nodes, :list_nodes, [[]]}
           }
         ]
-        |> DNS.start_link()
+        |> DNS.ConnectOnly.start_link()
 
         assert_receive {:connect, :"node@10.0.0.1"}, 100
         assert_receive {:connect, :"node@10.0.0.2"}, 100
       end)
     end
 
-    test "removes nodes" do
+    test "node not returned by DNS resolver is not disconnected" do
       capture_log(fn ->
         [
           %State{
@@ -53,9 +53,9 @@ defmodule Cluster.Strategy.KubernetesDNSTest do
             meta: MapSet.new([:"node@10.0.0.1", :"node@10.0.0.2"])
           }
         ]
-        |> DNS.start_link()
+        |> DNS.ConnectOnly.start_link()
 
-        assert_receive {:disconnect, :"node@10.0.0.2"}, 100
+        refute_receive {:disconnect, :"node@10.0.0.2"}, 100
       end)
     end
 
@@ -76,7 +76,7 @@ defmodule Cluster.Strategy.KubernetesDNSTest do
             meta: MapSet.new([:"node@10.0.0.1"])
           }
         ]
-        |> DNS.start_link()
+        |> DNS.ConnectOnly.start_link()
 
         refute_receive {:disconnect, _}, 100
         refute_receive {:connect, _}, 100
@@ -99,7 +99,7 @@ defmodule Cluster.Strategy.KubernetesDNSTest do
             list_nodes: {Nodes, :list_nodes, [[]]}
           }
         ]
-        |> DNS.start_link()
+        |> DNS.ConnectOnly.start_link()
 
         refute_receive {:connect, _}, 100
         refute_receive {:disconnect, _}, 100


### PR DESCRIPTION
### Summary of changes

  This is the same as Cluster.Strategy.Kubernetes.DNS, but
  it does not pro-actively disconnect nodes that do not appear in the DNS
  resolver response.
  We let Erlang Distribution take care of disconnecting nodes
